### PR TITLE
player.currentSrc is empty in Chrome #2

### DIFF
--- a/jquery.playlist.js
+++ b/jquery.playlist.js
@@ -101,7 +101,7 @@
 
         return this.each(function() {
             var player = this;
-            var src = player.currentSrc;
+            var src = $(player).attr('src');
             var extension = fileExtension(src);
             var playlist = new Array();
             var current = -1;


### PR DESCRIPTION
Using attr() makes it work on every browser.
